### PR TITLE
Allow React 18 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "@storybook/core-events": "^6.4.0",
     "@storybook/theming": "^6.4.0",
     "jotai": "^1.0.0",
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
     "react": {


### PR DESCRIPTION
The addon seems to be working fine when I override `react` in my `package.json`.