### PR TITLE
Support Jotai v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "boxen": "^6.2.1",
     "concurrently": "^7.0.0",
     "dedent": "^0.7.0",
-    "jotai": "^1.5.0",
+    "jotai": "^2.1.0",
     "prettier": "^2.3.1",
     "prop-types": "^15.7.2",
     "react": "^17.0.1",
@@ -64,7 +64,7 @@
     "@storybook/components": "^6.4.0",
     "@storybook/core-events": "^6.4.0",
     "@storybook/theming": "^6.4.0",
-    "jotai": "^1.0.0",
+    "jotai": "^2.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 import { atom } from "jotai";
-import type { Atom } from "jotai";
+import type { WritableAtom } from "jotai";
 
 export const ADDON_ID = "storybook/jotai-addon";
 export const PANEL_ID = `${ADDON_ID}/panel`;
@@ -10,10 +10,13 @@ export const EVENTS = {
   RENDERED: `${ADDON_ID}/rendered`,
 };
 
+export type AnyWritableAtom = WritableAtom<unknown, any[], any>;
+export type InitialValues = (readonly [AnyWritableAtom, unknown])[];
+
 export const createInitialValues = () => {
-  const initialValues: (readonly [Atom<unknown>, unknown])[] = []
+  const initialValues: InitialValues = []
   const get = () => initialValues
-  const set = <Value>(anAtom: Atom<Value>, value: Value) => {
+  const set = <Value>(anAtom: AnyWritableAtom, value: Value) => {
     initialValues.push([anAtom, value])
   }
   return { get, set }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6612,10 +6612,10 @@ jest-worker@^26.5.0, jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jotai@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.6.0.tgz#81412756dab42fcb712530fba512e5e43bd0de15"
-  integrity sha512-J/+aD9R1XDcNeY8drg/y/I47eUivQ13HGmLmA33w95SvJJLBStSF5WxYrmLgbuWcDC6MpRecF3g/GBchPJNcZg==
+jotai@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.1.0.tgz#b1a9525345518453802e4a64d99e2800598bab76"
+  integrity sha512-fR82PtHAmEQrc/daMEYGc4EteW96/b6wodtDSCzLvoJA/6y4YG70er4hh2f8CYwYjqwQ0eZUModGfG4DmwkTyQ==
 
 js-string-escape@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I wanted to reach out and let you know that I have completed the update to the Storybook plugin for `storybook-addon-jotai` to support Jotai v2. Previously, the plugin only supported Jotai v1, but with this update, it will now be compatible with the latest version of Jotai.

I would like to submit a Pull Request for your review, as I believe this update will greatly benefit users of the `storybook-addon-jotai` by providing them with an improved and up-to-date plugin.

Please let me know if there is anything else you need from me or if you have any questions about the changes I have made. I look forward to hearing back from you and appreciate your time in reviewing the code.

Thank you for your consideration.

### Changes:

- Removed the initialValues prop from the Provider.
  This change was made in accordance with the information provided in the following document: https://jotai.org/docs/guides/migrating-to-v2-api#new-api.
- Updated the plugin to accommodate changes made to the Atom type.
- Updated the plugin to accommodate changes made to the location of useAtomValue.

closes #16